### PR TITLE
efence: Add electric fence to default manifest.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -140,6 +140,7 @@
   <project path="external/blktrace" name="platform/external/blktrace" groups="pdk-cw-fs" remote="aosp" />
   <!--<project path="external/bluetooth/bluedroid" name="CyanogenMod/android_external_bluetooth_bluedroid" groups="pdk" />-->
   <project path="external/bouncycastle" name="CyanogenMod/android_external_bouncycastle" />
+  <project path="external/efence" name="CyanogenMod/android_external_boundarydevices_efence" />
   <project path="external/bsdiff" name="platform/external/bsdiff" groups="pdk" remote="aosp" />
   <project path="external/bson" name="CyanogenMod/android_external_bson" />
   <project path="external/busybox" name="CyanogenMod/android_external_busybox" />


### PR DESCRIPTION
Electric Fence is a different kind of malloc() debugger. It uses the virtual
memory hardware of your system to detect when software overruns the boundaries
of a malloc() buffer. It will also detect any accesses of memory that has
been released by free(). Because it uses the VM hardware for detection,
Electric Fence stops your program on the first instruction that causes
a bounds violation. It's then trivial to use a debugger to display the
offending statement.

Change-Id: I49557db5c57aa897d965f0a47b411c3d756f5880